### PR TITLE
Build minimal smalltalk transformer core

### DIFF
--- a/me.py
+++ b/me.py
@@ -1,0 +1,68 @@
+import random
+from typing import List, Tuple, Set
+from memory import init_db, tokenize, get_vocab, metrics
+from rag import retrieve
+from method import train
+
+
+class Engine:
+    def __init__(self) -> None:
+        init_db()
+
+    def _lengths(self, entropy: float, perplexity: float) -> Tuple[int, int]:
+        base1 = 5 + int(entropy) % 5
+        base2 = 5 + int(perplexity) % 5
+        if base1 == base2:
+            base2 = 5 + ((base2 + 1) % 5)
+        return base1, base2
+
+    def _generate(self, words: List[str], distance: float, length: int, used: Set[str]) -> str:
+        vocab = get_vocab()
+        _, _, resonance = metrics(words, vocab)
+        pronouns = {'you': 'i', 'u': 'i', 'i': 'you', 'me': 'you', 'we': 'you'}
+        pronoun = next((pronouns[w] for w in words if w in pronouns), None)
+        candidates = retrieve(words, distance=distance)
+        random.shuffle(candidates)
+        sent: List[str] = []
+        if pronoun and pronoun not in used:
+            sent.append(pronoun)
+            used.add(pronoun)
+        for w in candidates:
+            if len(sent) >= length:
+                break
+            if w in words or w in used:
+                continue
+            if w == 'the' and len(sent) > 0:
+                w = 'the'
+            sent.append(w)
+            used.add(w)
+        while len(sent) < length:
+            choice = random.choice(candidates) if candidates else 'hmm'
+            if choice not in sent and choice not in words and choice not in used:
+                sent.append(choice)
+                used.add(choice)
+        if len(sent[-1]) == 1:
+            sent[-1] = 'hmm'
+        sent[0] = sent[0].capitalize()
+        return ' '.join(sent) + '.'
+
+    def reply(self, message: str) -> str:
+        words = tokenize(message)
+        vocab = get_vocab()
+        entropy, perplexity, _ = metrics(words, vocab)
+        len1, len2 = self._lengths(entropy, perplexity)
+        used: Set[str] = set()
+        first = self._generate(words, 0.5, len1, used)
+        second = self._generate(words, 0.7, len2, used)
+        train(message)
+        return f"{first} {second}"
+
+
+if __name__ == '__main__':
+    bot = Engine()
+    try:
+        while True:
+            msg = input('> ')
+            print(bot.reply(msg))
+    except KeyboardInterrupt:
+        pass

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,46 @@
+import sqlite3
+import math
+import time
+import re
+from typing import List, Tuple, Dict
+
+DB_PATH = 'memory.db'
+
+def init_db() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('CREATE TABLE IF NOT EXISTS dialog (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT, ts REAL)')
+        c.execute('CREATE TABLE IF NOT EXISTS vocab (word TEXT PRIMARY KEY, count INTEGER)')
+        conn.commit()
+
+def tokenize(text: str) -> List[str]:
+    return [w.lower() for w in re.findall(r"[a-zA-Z']+", text)]
+
+def log_message(message: str) -> None:
+    words = tokenize(message)
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('INSERT INTO dialog (message, ts) VALUES (?, ?)', (message, time.time()))
+        for w in words:
+            c.execute('INSERT INTO vocab (word, count) VALUES (?, 1) ON CONFLICT(word) DO UPDATE SET count=count+1', (w,))
+        conn.commit()
+
+def get_recent_messages(n: int = 20) -> List[str]:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('SELECT message FROM dialog ORDER BY id DESC LIMIT ?', (n,))
+        return [row[0] for row in c.fetchall()]
+
+def get_vocab() -> Dict[str, int]:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('SELECT word, count FROM vocab')
+        return {w: cnt for w, cnt in c.fetchall()}
+
+def metrics(words: List[str], vocab: Dict[str, int]) -> Tuple[float, float, str]:
+    total = sum(vocab.values()) or 1
+    probs = [vocab.get(w, 1) / total for w in words] or [1 / total]
+    entropy = -sum(p * math.log2(p) for p in probs)
+    perplexity = 2 ** entropy
+    resonance_word = min(words, key=lambda w: vocab.get(w, 1)) if words else ''
+    return entropy, perplexity, resonance_word

--- a/method.py
+++ b/method.py
@@ -1,0 +1,13 @@
+import sqlite3
+from memory import DB_PATH, tokenize, log_message
+
+
+def train(user_message: str) -> None:
+    log_message(user_message)
+    words = tokenize(user_message)
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('CREATE TABLE IF NOT EXISTS bigram (w1 TEXT, w2 TEXT, count INTEGER, PRIMARY KEY (w1, w2))')
+        for a, b in zip(words, words[1:]):
+            c.execute('INSERT INTO bigram (w1, w2, count) VALUES (?, ?, 1) ON CONFLICT(w1, w2) DO UPDATE SET count=count+1', (a, b))
+        conn.commit()

--- a/rag.py
+++ b/rag.py
@@ -1,0 +1,23 @@
+import random
+import pathlib
+from typing import List, Iterable
+from memory import get_recent_messages, tokenize
+
+DATA_PATH = pathlib.Path(__file__).with_name('smalltalk.md')
+
+
+def dataset_words() -> List[str]:
+    if DATA_PATH.exists():
+        text = DATA_PATH.read_text(encoding='utf-8')
+        return list(set(tokenize(text)))
+    return []
+
+
+def retrieve(query_words: Iterable[str], distance: float = 0.5) -> List[str]:
+    base = set(dataset_words())
+    for msg in get_recent_messages():
+        base.update(tokenize(msg))
+    base = [w for w in base if w not in set(query_words)]
+    random.shuffle(base)
+    k = max(1, int(len(base) * distance))
+    return base[:k]


### PR DESCRIPTION
## Summary
- implement sqlite-backed memory, vocabulary metrics and logging
- create retrieval module to mix dataset and memory for responses
- add on-the-fly training and simple Markov memory
- wire engine for smalltalk replies with distance-based sentence generation

## Testing
- `python -m py_compile me.py memory.py method.py rag.py`
- `python - <<'PY'\nfrom me import Engine\nbot = Engine()\nprint(bot.reply('hello you curious observer'))\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68b63a857c4c8329802095bce053be7a