### PR TITLE
Pin Python dependencies for stable builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-python-telegram-bot>=21
-python-dotenv
+python-telegram-bot==22.3
+python-dotenv==1.1.1
+httpx==0.28.1


### PR DESCRIPTION
## Summary
- Pin python-telegram-bot and python-dotenv versions
- Explicitly add httpx dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b7834be9dc8329b928ab111c0951b4