### PR TITLE
Simplify start command reply

### DIFF
--- a/merobot.py
+++ b/merobot.py
@@ -46,9 +46,7 @@ class MeBot:
     
     async def start_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle the /start command."""
-        await update.message.reply_text(
-            "Hello! I'm the ME bot. Send me any message and I'll respond using the ME engine."
-        )
+        await update.message.reply_text("Hello!")
         logger.info(f"Start command from user {update.effective_user.id}")
     
     async def help_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Simplify bot `/start` response to a plain "Hello!" message

## Testing
- `pytest`
- `flake8` *(fails: command not found)*
- `python - <<'PY'
import asyncio
from merobot import MeBot
class DummyMessage:
    def __init__(self):
        self.text = ''
    async def reply_text(self, text):
        print('BOT_REPLY:', text)
class DummyUser:
    id = 123
class DummyUpdate:
    effective_user = DummyUser()
    message = DummyMessage()
async def test():
    bot = MeBot()
    await bot.start_command(DummyUpdate(), None)
asyncio.run(test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b78bf8add4832980bab25820ceb139