### PR TITLE
refactor: async session creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot==22.3
 python-dotenv==1.1.1
 httpx==0.28.1
+aiosqlite==0.20.0


### PR DESCRIPTION
## Summary
- use aiosqlite with a shared connection for sessions
- make start_session async and simplify spawn_session
- add aiosqlite to requirements

## Testing
- `python -m py_compile me2me.py`
- `pytest`
- `flake8 me2me.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7929ec0cc8329b63ff2df08beeb70