### PR TITLE
Async bigram training with shared connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The engine then calculates semantic distance, choosing two word sets: one roughl
 
 After each exchange, the method module performs on-the-fly training by recording bigram transitions. Over time this evolving Markov chain shapes probabilities, letting the engine adapt to the user's style without any initial training phase.
 
+Retraining happens asynchronously. The `train` coroutine updates a shared SQLite connection, maintaining an indexed `bigram` table on `(w1, w2)` so counts can be incremented in parallel with reply generation without locking delays.
+
 Pronoun inversion enforces a subtle perspective shift. When the user says "you," the engine gravitates toward "I" or "me," and when "I" appears, it reflects back with "you." This interplay fosters a sense of subjectivity in every reply.
 
 Strict word filters prevent repetition and enforce spacing rules: no single-letter endings, no consecutive one-character words, and no mid-sentence capital "The." These small guards sustain conversational clarity while adding an organic tone.

--- a/me.py
+++ b/me.py
@@ -70,7 +70,6 @@ class Engine:
     async def reply(self, message: str) -> str:
         words = tokenize(message)
         vocab = get_vocab()
-        train_future = asyncio.create_task(asyncio.to_thread(train, message))
 
         async def generate() -> str:
             metrics_future = asyncio.create_task(asyncio.to_thread(metrics, words, vocab))
@@ -91,7 +90,7 @@ class Engine:
             return f"{first} {second}"
 
         reply_text, _ = await asyncio.gather(
-            generate(), train_future
+            generate(), train(message)
         )
         return reply_text
 

--- a/method.py
+++ b/method.py
@@ -1,13 +1,39 @@
-import sqlite3
+import asyncio
+from typing import Optional
+
+import aiosqlite
+
 from memory import DB_PATH, tokenize, log_message
 
 
-def train(user_message: str) -> None:
-    log_message(user_message)
+DB_CONN: Optional[aiosqlite.Connection] = None
+
+
+async def get_conn() -> aiosqlite.Connection:
+    """Return a shared aiosqlite connection and ensure schema."""
+    global DB_CONN
+    if DB_CONN is None:
+        DB_CONN = await aiosqlite.connect(DB_PATH)
+        await DB_CONN.execute(
+            'CREATE TABLE IF NOT EXISTS bigram (w1 TEXT, w2 TEXT, count INTEGER, PRIMARY KEY (w1, w2))'
+        )
+        await DB_CONN.execute(
+            'CREATE INDEX IF NOT EXISTS idx_bigram_w1_w2 ON bigram(w1, w2)'
+        )
+        await DB_CONN.commit()
+    return DB_CONN
+
+
+async def train(user_message: str) -> None:
+    """Update bigram counts based on the user's message."""
+    await asyncio.to_thread(log_message, user_message)
     words = tokenize(user_message)
-    with sqlite3.connect(DB_PATH) as conn:
-        c = conn.cursor()
-        c.execute('CREATE TABLE IF NOT EXISTS bigram (w1 TEXT, w2 TEXT, count INTEGER, PRIMARY KEY (w1, w2))')
-        for a, b in zip(words, words[1:]):
-            c.execute('INSERT INTO bigram (w1, w2, count) VALUES (?, ?, 1) ON CONFLICT(w1, w2) DO UPDATE SET count=count+1', (a, b))
-        conn.commit()
+    conn = await get_conn()
+    for a, b in zip(words, words[1:]):
+        await conn.execute(
+            'INSERT INTO bigram (w1, w2, count) VALUES (?, ?, 1) '
+            'ON CONFLICT(w1, w2) DO UPDATE SET count=count+1',
+            (a, b),
+        )
+    await conn.commit()
+


### PR DESCRIPTION
## Summary
- Refactor `method.train` into an async coroutine using a shared aiosqlite connection and an index on `(w1, w2)`
- Update `Engine.reply` to await `train` directly
- Document asynchronous retraining and indexed bigram updates

## Testing
- `python -m py_compile method.py me.py`
- `pytest`
- `flake8` *(failed: command not found / install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a2733e648329aa7a9ab994d0dac8